### PR TITLE
Fix nginx reverse proxy not to decode request paths.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -129,6 +129,19 @@ Keycloak is configured for use with Fairspace at first startup, using the
 comment out the `KEYCLOAK_IMPORT` line in [keycloak.yml](keycloak.yml) and configure the Keycloak realm manually,
 following the instructions from [Fairspace documentation](../README.adoc) on how to configure a Keycloak realm for Fairspace.
 
+Importing the realm template results in:
+- creating a `fairspace` realm,
+- creating a default client `fairspace-client` with secret: `"**********"` that should be regenerated after starting Keycloak,
+- adding a default user that has a `superadmin` role with username: `"organisation-admin"` and password: `"keycloak123"`
+  (to be changed in Keycloak Administration Console after starting Keycloak).
+
+In order to regenerate the `fairspace-client` secret:
+1. Open the Keycloak Administration Console (default username: `keycloak`, default password: `keycloak`),
+2. Open `fairspace` realm settings,
+3. Go to Clients and select `fairspace-client`,
+4. Open "Credentials" tab and clisk on "Regenerate Secret" button,
+5. Copy the newly generated secret into the `.env` file and restart fairspace-saturn and fairspace-pluto containers.
+
 ## Running everything together 
 
 After configuring the `.env` file and certificates, the `docker-compose` script can be run.
@@ -178,6 +191,9 @@ required:
     extra_hosts:
       - "keycloak:172.17.0.1"
     ```
+   Where the `172.17.0.1` is the IP address of the gateway between the Docker host and the bridge network default for Docker on Linux. 
+   If using a different Operating System, the IP address has to be changed accordingly.
+
 3. Set these local aliases as host names in the `.env` file:
     ```properties
     KEYCLOAK_SERVER_URL=https://keycloak

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - nginx-proxy-network
       - fairspace-db-network
 #    extra_hosts:
-#      - "fairspace-keycloak:172.17.0.1"
+#      - ${KEYCLOAK_HOSTNAME}:172.17.0.1
 
   fairspace-pluto:
     image: ${PLUTO_IMAGE}
@@ -82,7 +82,7 @@ services:
     networks:
       - nginx-proxy-network
 #    extra_hosts:
-#      - "fairspace-keycloak:172.17.0.1"
+#      - ${KEYCLOAK_HOSTNAME}:172.17.0.1
 
 
 volumes:

--- a/docker/fairspace-ssl-proxy/entrypoint.sh
+++ b/docker/fairspace-ssl-proxy/entrypoint.sh
@@ -12,7 +12,7 @@ cat > /etc/nginx/sites-enabled/fairspace.conf <<EndOfMessage
      ssl_certificate_key   /etc/nginx/server.key;
      index                 index.html;
      location / {
-       proxy_pass            http://172.17.0.1:9080/;
+       proxy_pass            http://172.17.0.1:9080;
        proxy_read_timeout    90s;
        proxy_connect_timeout 90s;
        proxy_send_timeout    90s;
@@ -42,7 +42,7 @@ cat > /etc/nginx/sites-enabled/keycloak.conf <<EndOfMessage
      ssl_certificate_key   /etc/nginx/server.key;
      index                 index.html;
      location / {
-       proxy_pass            http://172.17.0.1:8080/;
+       proxy_pass            http://172.17.0.1:8080;
        proxy_read_timeout    90s;
        proxy_connect_timeout 90s;
        proxy_send_timeout    90s;


### PR DESCRIPTION
Short explanation to the nginx related change can be found in the documentation: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass

> If the proxy_pass directive is specified with a URI, then when a request is passed to the server, the part of a [normalized](http://nginx.org/en/docs/http/ngx_http_core_module.html#location) request URI matching the location is replaced by a URI specified in the directive:

    location /name/ {
        proxy_pass http://127.0.0.1/remote/;
    }

> If proxy_pass is specified without a URI, the request URI is passed to the server in the same form as sent by a client when the original request is processed, or the full normalized request URI is passed when processing the changed URI:

    location /some/path/ {
        proxy_pass http://127.0.0.1;
    }